### PR TITLE
Add "mechanize" in install_requires, in setup file, as it is necessary to run the module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     version="1.023",
     packages=find_packages(),
     author="megadose",
-    install_requires=["requests","evolut","argparse","termcolor","tqdm"],
+    install_requires=["requests","evolut","argparse","termcolor","tqdm", "mechanize"],
     description="holehe allows you to check if the mail is used on different sites like twitter, instagram and will retrieve information on sites with the forgotten password function.",
     include_package_data=True,
     url='http://github.com/megadose/holehe',


### PR DESCRIPTION
Changed from `install_requires=["requests","evolut","argparse","termcolor","tqdm"]` to
`install_requires=["requests","evolut","argparse","termcolor","tqdm", "mechanize"]`

Module "mechanize" is necessary to run Holehe, as seen in third line of core.py file. Yet, it is not requested in install_requires, which raises ModuleNotFound error.