### PR TITLE
added "fake_useragent"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     version="1.024",
     packages=find_packages(),
     author="megadose",
-    install_requires=["requests","evolut","argparse","termcolor","tqdm", "mechanize"],
+    install_requires=["requests","evolut","argparse","termcolor","tqdm", "mechanize", "fake_useragent"],
     description="holehe allows you to check if the mail is used on different sites like twitter, instagram and will retrieve information on sites with the forgotten password function.",
     include_package_data=True,
     url='http://github.com/megadose/holehe',


### PR DESCRIPTION
Changed from `install_requires=["requests","evolut","argparse","termcolor","tqdm", "mechanize"]` to
`install_requires=["requests","evolut","argparse","termcolor","tqdm", "mechanize", "fake_useragent"]`

Module "fake_useragent" is necessary to run Holehe, as seen in ninth line of core.py file. Yet, it is not requested in install_requires, which raises ModuleNotFound error.

File "----\Python38\lib\site-packages\holehe\core.py", line 9, in <module>
    from fake_useragent import UserAgent
ModuleNotFoundError: No module named 'fake_useragent'