### PR TITLE
Fix httpx-api allow_redirects to follow_redirects

### DIFF
--- a/holehe/modules/crm/axonaut.py
+++ b/holehe/modules/crm/axonaut.py
@@ -22,7 +22,7 @@ async def axonaut(email, client, out):
     }
 
 
-    response = await client.get('https://axonaut.com/onboarding/?email='+email, headers=headers,allow_redirects=False)
+    response = await client.get('https://axonaut.com/onboarding/?email='+email, headers=headers,follow_redirects=False)
 
     if response.status_code == 302 and "/login?email" in str(response.headers['Location']):
         out.append({"name": name,"domain":domain,"method":method,"frequent_rate_limit":frequent_rate_limit,

--- a/holehe/modules/software/office365.py
+++ b/holehe/modules/software/office365.py
@@ -18,13 +18,13 @@ async def office365(email, client, out):
         'https://outlook.office365.com/autodiscover/autodiscover.json/v1.0/{}?Protocol=Autodiscoverv1'.format(
             get_random_string(30)+"@"+email.split('@')[1]),
         headers=headers,
-        allow_redirects=False)
+        follow_redirects=False)
     if r.status_code != 200:
         r = await client.get(
             'https://outlook.office365.com/autodiscover/autodiscover.json/v1.0/{}?Protocol=Autodiscoverv1'.format(
                 email),
             headers=headers,
-            allow_redirects=False)
+            follow_redirects=False)
         if r.status_code == 200:
             out.append({"name": name,"domain":domain,"method":method,"frequent_rate_limit":frequent_rate_limit,
                         "rateLimit": False,


### PR DESCRIPTION
Hi,
As you can see Httpx not support `allow_redirects`. Use instead of that, `follow_redirects`.

https://github.com/encode/httpx/blob/e1abaf146fe1b66c0d5ae10a24106865efe2d79e/httpx/_api.py#L175