### PR TITLE
Update instagram.py

### DIFF
--- a/holehe/modules/social_media/instagram.py
+++ b/holehe/modules/social_media/instagram.py
@@ -19,7 +19,7 @@ async def instagram(email, client, out):
 
     try:
         freq = await client.get("https://www.instagram.com/accounts/emailsignup/", headers=headers)
-        token = freq.text.split('{"config":{"csrf_token":"')[1].split('"')[0]
+        token = freq.text.split('{\\"config\\":{\\"csrf_token\\":\\"')[1].split('\\"')[0]
     except Exception:
         out.append({"name": name,"domain":domain,"method":method,"frequent_rate_limit":frequent_rate_limit,
                     "rateLimit": True,
@@ -31,13 +31,13 @@ async def instagram(email, client, out):
 
     data = {
         'email': email,
-        'username': '',
+        'username': 'not_existing_user_not_existing_user_not_existing_user',
         'first_name': '',
         'opt_into_one_tap': 'false'
     }
     headers["x-csrftoken"] = token
     check = await client.post(
-        "https://www.instagram.com/accounts/web_create_ajax/attempt/",
+        "https://www.instagram.com/api/v1/web/accounts/web_create_ajax/attempt/",
         data=data,
         headers=headers)
     check = check.json()


### PR DESCRIPTION
# Instagram module

## Issue

When running Holehe instagram always gave me Rate limit.

## Changes

### CSRF token

I noticed that the problem was given by a wrong parse of the html body when searching for the token.
I simply added the escape characters when splitting the text.

### Username in POST request

Instagram requires to add a username. I put a static name but it may be a good idea to generate a new random one every time.

### POST request URL
Instagram now sends requests to this URL when creating the account: https://www.instagram.com/api/v1/web/accounts/web_create_ajax/attempt/.

