### PR TITLE
Update yahoo.py

### DIFF
--- a/holehe/modules/mails/yahoo.py
+++ b/holehe/modules/mails/yahoo.py
@@ -82,6 +82,13 @@ async def yahoo(email, client, out):
                             "emailrecovery": None,
                             "phoneNumber": None,
                             "others": None})
+        elif "location" in response.keys():
+            out.append({"name": name,"domain":domain,"method":method,"frequent_rate_limit":frequent_rate_limit,
+                            "rateLimit": False,
+                            "exists": False,
+                            "emailrecovery": None,
+                            "phoneNumber": None,
+                            "others": None})
         else:
             out.append({"name": name,"domain":domain,"method":method,"frequent_rate_limit":frequent_rate_limit,
                         "rateLimit": True,


### PR DESCRIPTION
## Issue

When sending a POST request to https://login.yahoo.com/ with a non existing account such as example@**gmail.com**, the server responds with a JSON containing a "location" key that points to */account/challenge/fail?*.

The page displays "We can't sign you in right now. Please try again in a while.".

In this case the output of holehe for the yahoo module is *Rate limit*. 

## Solution

Adding a new elif statement 

```
elif "location" in response.keys():
```

we find out that the email provided does not belong to yahoo.com so in the output we will get an *Email not used* rather than *Rate limit*.