### PR TITLE
Update adobe.py

### DIFF
--- a/holehe/modules/software/adobe.py
+++ b/holehe/modules/software/adobe.py
@@ -24,12 +24,10 @@ async def adobe(email, client, out):
         r = await client.post(
             'https://auth.services.adobe.com/signin/v1/authenticationstate',
             headers=headers,
-            json=data)
-                
-        headers['X-IMS-Authentication-State-Encrypted'] = r.headers['x-ims-authentication-state-encrypted']
+            json=data)        
     
-        r = r.json()
-        if "errorCode" in str(r.keys()):
+        j = r.json()
+        if "errorCode" in str(j.keys()):
             out.append({"name": name,"domain":domain,"method":method,"frequent_rate_limit":frequent_rate_limit,
                         "rateLimit": False,
                         "exists": False,
@@ -37,6 +35,8 @@ async def adobe(email, client, out):
                         "phoneNumber": None,
                         "others": None})
             return None
+        
+        headers['X-IMS-Authentication-State-Encrypted'] = r.headers['x-ims-authentication-state-encrypted']
         params = {
             'purpose': 'passwordRecovery',
         }


### PR DESCRIPTION
## Issue

![s3](https://user-images.githubusercontent.com/72035730/225152639-1659b285-a730-4927-b668-67f83abb8d8b.png)

When the second POST to retrieve challenges methods is made, the returned JSON is

``` json
{"errorCode": "invalid_token", "errorMessage": "Start over the login process!"}
```

which causes holehe to display Rate Limit for adobe even if the email exists.

The token needed must be placed in the request header *X-Ims-Authentication-State-Encrypted* instead of *X-Ims-Authentication-State*.

The token is obtained from the first response headers.

## Solution

Before the second request is made I appended the header *X-IMS-Authentication-State-Encrypted* to the headers defined for the first request. There's no need to specify again the ClientId header because it uses the previously defined.

If the first request doesn't return "errorCode" in the JSON response then the email exists. That's why I added the following if statement after the second request. We may not know if the user enabled the multifactor authentication but we know the email exists.

``` python
if 'errorCode' in response:
    ...
    "rateLimit": False,
    "exists": True,
    "emailrecovery": None,
    "phoneNumber": None,
    ...
else:
    ...
    "rateLimit": False,
    "exists": True,
    "emailrecovery": response['secondaryEmail'],
    "phoneNumber": response['securityPhoneNumber']
    ...
```

### Email registered

![s2](https://user-images.githubusercontent.com/72035730/225152736-20889447-ad1c-4589-b931-18b481c656f4.png)

### Email not registered

![s1](https://user-images.githubusercontent.com/72035730/225152810-cce9992c-e5c8-4fef-866b-86071a36957e.png)