### PR TITLE
Fix ebay.py

### DIFF
--- a/holehe/modules/shopping/ebay.py
+++ b/holehe/modules/shopping/ebay.py
@@ -38,7 +38,7 @@ async def ebay(email, client, out):
         'https://signin.ebay.com/signin/srv/identifer',
         data=data, headers=headers)
     results = json.loads(req.text)
-    if "err" in results.keys():
+    if "errorMsg" in results.keys():
         out.append({"name": name,"domain":domain,"method":method,"frequent_rate_limit":frequent_rate_limit,
                     "rateLimit": False,
                     "exists": False,


### PR DESCRIPTION
In the "results.keys()" there wasn't a key called "err", hence the modules was returning only True. 

dict_keys(['webAuthnModel', 'roamingAuthModel', 'passkeysModel', 'isPersonalizedSignin', 'errorMsg'])