### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.11-slim-bullseye
 COPY . /opt/holehe
 WORKDIR /opt/holehe
-RUN python3 setup.py install
+RUN pip3 install requests && \
+    python3 setup.py install


### PR DESCRIPTION
Requests is no more installed in python:3.11-slim-bullseye image.

Issue: #209