### PR TITLE
update version checker to load the JSON response

### DIFF
--- a/holehe/core.py
+++ b/holehe/core.py
@@ -64,8 +64,8 @@ def get_functions(modules,args=None):
 
 def check_update():
     """Check and update holehe if not the last version"""
-    check_version = httpx.get("https://pypi.org/pypi/holehe/json")
-    if check_version.json()["info"]["version"] != __version__:
+    check_version = httpx.get("https://pypi.org/pypi/holehe/json").text
+    if json.loads(check_version)["info"]["version"] != __version__:
         if os.name != 'nt':
             p = Popen(["pip3",
                        "install",


### PR DESCRIPTION
The current way of pulling the latest release and checking for updates is broken because httpx is returning a response type field which cannot be loaded using .json(). Instead we can get the text output (which will be a jsonified string) and load that with json.loads()