### PR TITLE
fix: CSV export crash due to inconsistent dict keys

### DIFF
--- a/holehe/core.py
+++ b/holehe/core.py
@@ -157,8 +157,10 @@ def export_csv(data,args,email):
         now = datetime.now()
         timestamp = datetime.timestamp(now)
         name_file="holehe_"+str(round(timestamp))+"_"+email+"_results.csv"
+        # Union de toutes les clés (ordre préservé par dict.fromkeys)
+        all_keys = list(dict.fromkeys(k for d in data for k in d.keys()))
         with open(name_file, 'w', encoding='utf8', newline='') as output_file:
-            fc = csv.DictWriter(output_file,fieldnames=data[0].keys())
+            fc = csv.DictWriter(output_file, fieldnames=all_keys, restval="", extrasaction="ignore")
             fc.writeheader()
             fc.writerows(data)
         exit("All results have been exported to "+name_file)
@@ -170,6 +172,8 @@ async def launch_module(module,email, client, out):
     except Exception:
         name=str(module).split('<function ')[1].split(' ')[0]
         out.append({"name": name,"domain":data[name],
+                    "method": "unknown",
+                    "frequent_rate_limit": False,
                     "rateLimit": False,
                     "error": True,
                     "exists": False,


### PR DESCRIPTION
## Problem

`holehe email@test.com -C` crashes with:
```
ValueError: dict contains fields not in fieldnames: 'frequent_rate_limit', 'method'
```

## Root cause

`export_csv()` uses `data[0].keys()` as `DictWriter` fieldnames, but modules and the `launch_module` error handler produce dicts with different key sets:

- **Modules** return: `method`, `frequent_rate_limit` (no `error`)
- **Error handler** returns: `error` (no `method`, no `frequent_rate_limit`)

When `data[0]` is an error dict (after alphabetical sort), fieldnames miss `method` and `frequent_rate_limit`, causing the crash on subsequent rows.

## Fix

- Collect union of all keys across all result dicts using `dict.fromkeys()` (preserves insertion order)
- Add missing `method` and `frequent_rate_limit` fields to `launch_module` error handler
- Add `restval=""` and `extrasaction="ignore"` as safety nets

## Testing

Tested with multiple email addresses — CSV now exports correctly with all 10 columns.

Fixes #44 #45